### PR TITLE
APP-5563: Release to npm registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "node-html-markdown",
+  "name": "@clearfeed-ai/node-html-markdown",
   "description": "Fast HTML to markdown cross-compiler, compatible with both node and the browser",
   "version": "1.4.1",
   "main": "dist/index.js",


### PR DESCRIPTION
We recently updated a few packages that had vulnerabilities.
Also, the main repo from which we forked this is not maintained anymore. Hence, releasing our own version of this
NPM release can be found [here](https://www.npmjs.com/package/@clearfeed-ai/node-html-markdown)