### PR TITLE
APP-7233 Fix removal of nested underscores

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -49,8 +49,9 @@ export function splitSpecial(s: string) {
 export function tagSurround(content: string, surroundStr: string) {
   // If un-escaped surroundStr already occurs, remove all instances
   // See: https://github.com/crosstype/node-html-markdown/issues/18
+  // We also do not need to remove nested underscores '_' as using underscores is common in texts
   const nestedSurroundStrIndex = content.indexOf(surroundStr);
-  if (nestedSurroundStrIndex >= 0)
+  if (nestedSurroundStrIndex >= 0 && surroundStr !== '_') 
     content = content.replace(
       new RegExp(`([^\\\\])\\${surroundStr.split('').join('\\')}`, 'gm'),
       '$1'


### PR DESCRIPTION
- For italic texts the underscores are being removed 
- `tagSurround` has a change for removing nested tags 
- for underscores it removes all the underscores which is sometimes required [context](https://clearfeed.slack.com/archives/C02RX64MPK2/p1745515195019869)
- one of the issues for the above slack thread is the underscores being removed 
- adding a check just for underscores should solve the issue

### Screen shots 
![Screenshot 2025-05-12 at 10 45 28 AM](https://github.com/user-attachments/assets/425fcfd5-622b-4429-aebc-ea9667ebb301)
before - 
![Screenshot 2025-05-12 at 10 53 38 AM](https://github.com/user-attachments/assets/b2c6f64f-9690-474a-a0f8-4f19bcbba4d2)

after- 

![Screenshot 2025-05-12 at 10 45 34 AM](https://github.com/user-attachments/assets/4573c399-ad66-40b5-8279-f4b3e75b1928)
 
## testing backward sync zendesk 
![Screenshot 2025-05-12 at 11 21 15 AM](https://github.com/user-attachments/assets/e7f5668e-dafb-4c7c-851f-c9446d72d7e5)

before - 
![Screenshot 2025-05-12 at 11 21 23 AM](https://github.com/user-attachments/assets/03d2e422-d2df-4bfd-b7e5-1b27ef807915)

after - 
![Screenshot 2025-05-12 at 11 21 39 AM](https://github.com/user-attachments/assets/6c1090f3-3d23-4302-8bea-400341802a51)
