### PR TITLE
APP-8636 ai agent response formatting issue in automation node html markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clearfeed-ai/node-html-markdown",
   "description": "Fast HTML to markdown cross-compiler, compatible with both node and the browser",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -70,7 +70,8 @@ export const defaultOptions: Readonly<NodeHtmlMarkdownOptions> = Object.freeze({
     '$1$3\\$2$4'
   ] as const,
 
-  useInlineLinks: true
+  useInlineLinks: true,
+  preserveInlineNewlines: false
 });
 
 // endregion

--- a/src/options.ts
+++ b/src/options.ts
@@ -110,7 +110,13 @@ export interface NodeHtmlMarkdownOptions {
    *
    * @default true
    */
-  useInlineLinks?: boolean
+  useInlineLinks?: boolean,
+
+  /**
+   * Preserve newlines in inline elements while still allowing other processing
+   * @default false
+   */
+  preserveInlineNewlines?: boolean
 }
 
 // endregion

--- a/src/options.ts
+++ b/src/options.ts
@@ -115,7 +115,7 @@ export interface NodeHtmlMarkdownOptions {
   /**
    * Preserve newlines in inline elements while still allowing other processing
    * @default false
-   * As of current implementation this only applies when preserveWhitespace is false
+   * As of current implementation this only works when preserveWhitespace is false
    */
   preserveInlineNewlines?: boolean
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -115,6 +115,7 @@ export interface NodeHtmlMarkdownOptions {
   /**
    * Preserve newlines in inline elements while still allowing other processing
    * @default false
+   * As of current implementation this only applies when preserveWhitespace is false
    */
   preserveInlineNewlines?: boolean
 }

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -136,7 +136,15 @@ export class Visitor {
    */
   private processText(text: string, metadata: NodeMetadata | undefined) {
     let res = text;
-    if (!metadata?.preserveWhitespace) res = res.replace(/\s+/g, ' ');
+    if (!metadata?.preserveWhitespace) {
+      if (this.options.preserveInlineNewlines) {
+        // Preserve newlines, but normalize other whitespace
+        res = res.replace(/[^\S\r\n]+/g, ' ');
+      } else {
+        // Normalize all whitespace
+        res = res.replace(/\s+/g, ' ');
+      }
+    }
     if (metadata?.noEscape) return res;
 
     const { lineStartEscape, globalEscape, textReplace } = this.options;


### PR DESCRIPTION
# Fixes: Newlines in and other inline elements being converted to spaces

## Problem

AI agent responses with elements containing newlines become "congested" because the default whitespace normalization converts all newlines (`\n`) to spaces.

**Example:**

**Input:**
1\n2\n3\n4\n5
**Current Output:** `"1 2 3 4 5"` ❌ (newlines became spaces)  
**Expected Output:** `"1\n2\n3\n4\n5"` ✅ (preserve newlines)

---

## Solution

Added a new configuration option `preserveInlineNewlines` that allows selective newline preservation while maintaining all other markdown processing.

---

## Changes Made

**New Option Definition (`src/options.ts`)**
```
/**
 * Preserve newlines in inline elements while still allowing other processing
 * @default false
 */
```
preserveInlineNewlines?: boolean

Default:
preserveInlineNewlines: false // Maintains backward compatibility

Core Logic Update (src/visitor.ts)
```
if (!metadata?.preserveWhitespace) {
  if (this.options.preserveInlineNewlines) {
    // Preserve newlines, but normalize other whitespace
    res = res.replace(/[^\S\r\n]+/g, ' ');
  } else {
    // Original behavior - normalize all whitespace
    res = res.replace(/\s+/g, ' ');
  }
}
```

package.json
Version bump to 1.4.2


**Key Features ✅**
✅ Preserves newlines in inline elements when enabled
✅ Maintains bold/italic formatting (text → text)
✅ Allows all other markdown processing to continue normally
✅ Backwards compatible (preserveInlineNewlines: false by default)
✅ Minimal performance impact (single regex change)

**Implementation Details**

- The solution uses the regex /[^\S\r\n]+/g which:
- [^\S\r\n] = matches any whitespace character EXCEPT carriage (\r) returns and newlines
- Preserves \n and \r\n while normalizing spaces, tabs, and other whitespace
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes newline collapsing in AI agent automation responses by adding an option to preserve inline newlines during HTML→Markdown conversion. Addresses APP-8636 so 1\n2\n3 no longer becomes "1 2 3" when enabled.

- **New Features**
  - Added preserveInlineNewlines option (default false) to keep \n in inline text while still normalizing other whitespace.
  - Updated text processing to compress spaces/tabs but not newline characters.

- **Migration**
  - No change by default. To preserve inline newlines, set preserveInlineNewlines: true in NodeHtmlMarkdownOptions.

<!-- End of auto-generated description by cubic. -->

