### PR TITLE
APP-0000 Bump package version to 1.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clearfeed-ai/node-html-markdown",
   "description": "Fast HTML to markdown cross-compiler, compatible with both node and the browser",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
Bump the package version to 1.4.4 since 1.4.3 was already published before the https://github.com/clearfeed/node-html-markdown/pull/19 change