### PR TITLE
APP-0000: CVE-2026-33671 picomatch vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@clearfeed-ai/node-html-markdown",
   "description": "Fast HTML to markdown cross-compiler, compatible with both node and the browser",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2230,14 +2230,14 @@ picocolors@^1.1.1:
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 picomatch@^4.0.2:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 pirates@^4.0.7:
   version "4.0.7"


### PR DESCRIPTION
## Description

picomatch had vulnerable versions 2.3.1 and 4.0.3 installed. Upgraded them to 2.3.2 and 4.0.4.

CVE: https://www.cve.org/CVERecord?id=CVE-2026-33671
Dependabot: https://github.com/clearfeed/node-html-markdown/security/dependabot/39


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded `picomatch` to patched versions (2.3.2 and 4.0.4) to address CVE-2026-33671 and remove vulnerable ranges from the dependency tree. Bumped `@clearfeed-ai/node-html-markdown` to 1.4.5 and updated the lockfile; no application code changes.

<sup>Written for commit 78dcba93cec54f954ba1d9b9adac93425a038ce3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



